### PR TITLE
Start using the JobScheduler at Android 21

### DIFF
--- a/android/tsbackgroundfetch/src/main/java/com/transistorsoft/tsbackgroundfetch/BackgroundFetch.java
+++ b/android/tsbackgroundfetch/src/main/java/com/transistorsoft/tsbackgroundfetch/BackgroundFetch.java
@@ -77,7 +77,7 @@ public class BackgroundFetch {
     @TargetApi(21)
     public void start() {
         Log.d(TAG, "- start");
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             // API 21+ uses new JobScheduler API
             long fetchInterval = mConfig.getMinimumFetchInterval() * 60L * 1000L;
             JobScheduler jobScheduler = (JobScheduler) mContext.getSystemService(Context.JOB_SCHEDULER_SERVICE);
@@ -113,7 +113,7 @@ public class BackgroundFetch {
         if (mCompletionHandler != null) {
             mCompletionHandler.finish();
         }
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             JobScheduler jobScheduler = (JobScheduler) mContext.getSystemService(Context.JOB_SCHEDULER_SERVICE);
             if (jobScheduler != null) {
                 jobScheduler.cancel(FETCH_JOB_ID);
@@ -169,7 +169,7 @@ public class BackgroundFetch {
         } else if (mConfig.getJobService() != null) {
             finish();
             // Fire a headless background-fetch event.
-            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 // API 21+ uses JobScheduler API to fire a Job to application's configured jobService class.
                 JobScheduler jobScheduler = (JobScheduler) mContext.getSystemService(Context.JOB_SCHEDULER_SERVICE);
                 try {


### PR DESCRIPTION
All the `android.app.job` functionality was added in Android Lollipop (api level 21), but this plugin starts taking advantage of it in api level 22. Here I'm changing the conditionals from `Build.VERSION_CODES.LOLLIPOP_MR1` to `Build.VERSION_CODES.LOLLIPOP`