### PR TITLE
Update BackgroundFetch.java

### DIFF
--- a/android/tsbackgroundfetch/src/main/java/com/transistorsoft/tsbackgroundfetch/BackgroundFetch.java
+++ b/android/tsbackgroundfetch/src/main/java/com/transistorsoft/tsbackgroundfetch/BackgroundFetch.java
@@ -224,7 +224,7 @@ public class BackgroundFetch {
     public Boolean isMainActivityActive() {
         Boolean isActive = false;
 
-        if (mContext == null) {
+        if (mContext == null || mCallback == null) {
             return false;
         }
         ActivityManager activityManager = (ActivityManager) mContext.getSystemService(Context.ACTIVITY_SERVICE);


### PR DESCRIPTION
Hey- following up on my comment on react-native-background-fetch, this PR seems to fix the problem I was facing with enableHeadless: true

with forceReload: true, I think it will bring app to foreground which isn't desired behavior, but I think it will start running background-fetch again

with stopOnTerminate: true, I think it will try to terminate when app is killed by system (even if user doesn't swipe out), but it's not running anyway, so not sure if that's a big deal.

If this isn't a good solution, would be great to hear any suggested alternatives so we can fix this bug