### PR TITLE
fix: impossible to configure task if previous task has call stop(). (Android + Headless)

### DIFF
--- a/android/tsbackgroundfetch/src/main/java/com/transistorsoft/tsbackgroundfetch/BackgroundFetch.java
+++ b/android/tsbackgroundfetch/src/main/java/com/transistorsoft/tsbackgroundfetch/BackgroundFetch.java
@@ -153,6 +153,7 @@ public class BackgroundFetch {
                     }
                     BGTask.cancel(mContext, config.getTaskId(), config.getJobId());
                     config.destroy(mContext);
+                    mConfig.remove(config.getTaskId());
                 }
                 BGTask.clear();
             }
@@ -166,6 +167,9 @@ public class BackgroundFetch {
             if (config != null) {
                 config.destroy(mContext);
                 BGTask.cancel(mContext, config.getTaskId(), config.getJobId());
+                synchronized (mConfig) {
+                    mConfig.remove(config.getTaskId());
+                }
             }
         }
     }


### PR DESCRIPTION
I noticed that in my app:
**IF** 
 - I `configure()` a background-task
 - I run this task when my app is killed (using react-native headless)
 - I re-open my app and reconfigure a new task
 
**THEN** 
 - The second background task is not properly configured and not run properly
 
 # Reproducing the bug

I created a simple react-native app with minimal code to reproduce the bug
https://github.com/ACHP/rn-background-fetch-bug-repro

Run the app using react-native (checkout + yarn + yarn start + yarn android) 
- Then click on the blue "Register background fetch" button. (This will register a background task)
- Then you can kill your app and run the background task with `adb shell cmd jobscheduler run -f com.rnbgfetchbugrepro 999`
   - You should see a logger in the metro console indicating the task started, stopped, and finished.
- Then re-open the app and re-click the button
- Re-kill your app and re-run the headless task with `adb shell cmd jobscheduler run -f com.rnbgfetchbugrepro 999`
   - You should now see an error in the **logcat** console `[BGTask] failed to load config for taskId: react-native-background-fetch`
 
      
## Video of this process

https://github.com/user-attachments/assets/86a1d6b3-35c9-4115-92ae-fbb19bd82faf




## What is happening

From my research, I noticed that the second time we register the background task, it is not properly saved into the shared-preferences (We can see it in the video).
This happens because on this line, the mConfig hashmap still contains the taskId when we relaunch the app the second time.

https://github.com/transistorsoft/transistor-background-fetch/blob/7ad81a8fca982c4e7a2abcce440fb2d36716b207/android/tsbackgroundfetch/src/main/java/com/transistorsoft/tsbackgroundfetch/BackgroundFetch.java#L88

And the hashmap still contains the taskId because when we call `stop()`, it clean the shared-preferences, but not the mConfig hashmap.

https://github.com/transistorsoft/transistor-background-fetch/blob/7ad81a8fca982c4e7a2abcce440fb2d36716b207/android/tsbackgroundfetch/src/main/java/com/transistorsoft/tsbackgroundfetch/BackgroundFetch.java#L146-L170

That is why we see a `Re-configured existing task`, instead of a fresh "configure".
Then when we try to run the background task, it loads the config from the shared-preference, but it can't find nothing. So it fails with `[BGTask] failed to load config for taskId: react-native-background-fetch`


### Suggestion
We should probably clear the mConfig object when we stop the backgroundTask, so that there is no "desynchronisation" between the sharedPreference
